### PR TITLE
Couple of small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ Included are several Jupyter notebooks that implement sample code found in the L
 ## Setup
 - Click [Use this template](https://github.com/pjirsa/langchain-quickstart/generate)
 - Clone to your local machine -OR- open in Codespace
+- In a terminal, run `pip install -r requirements.txt`
 - Create a '.env' file at root of repo
 - Add `OPENAI_API_KEY="<your key here>"` to .env file

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ dataclasses-json==0.5.9
 frozenlist==1.3.3
 greenlet==2.0.2
 idna==3.4
-ipykernel=6.24.0
+ipykernel==6.24.0
 langchain==0.0.224
 langchainplus-sdk==0.0.20
 marshmallow==3.19.0
@@ -27,7 +27,7 @@ PyYAML==6.0
 requests==2.31.0
 SQLAlchemy==2.0.17
 tenacity==8.2.2
-tiktoken=0.4.0
+tiktoken==0.4.0
 tqdm==4.65.0
 typing-inspect==0.9.0
 typing_extensions==4.7.1


### PR DESCRIPTION
The requirements.txt file had a couple of missing == which caused the requirements installation to fail, so I addressed that.

I also added in a note under Setup in the readme to use the command to install the requirements before using the Jupyter notebooks (otherwise the first command won't run in the demo).